### PR TITLE
fix: incorrect activiti-cloud-modeling-dependencies artifactId

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>activiti-cloud-modeling-dependencies-parent</artifactId>
     <version>7.0.0-SNAPSHOT</version>
   </parent>
-  <artifactId>activiti-cloud-modeling-dependencies-dependencies</artifactId>
+  <artifactId>activiti-cloud-modeling-dependencies</artifactId>
   <packaging>pom</packaging>
   
   <name>Activiti Cloud Modeling :: BOM (Bill of Materials)</name>


### PR DESCRIPTION
Fixes wrong activiti-cloud-modeling-dependencies artifactId