### PR TITLE
updatebot should use master branch

### DIFF
--- a/.updatebot.yml
+++ b/.updatebot.yml
@@ -4,4 +4,6 @@ github:
   - name: activiti
     repositories:
     - name: activiti-cloud-modeling
-      branch: develop
+      branch: master
+    - name: activiti-cloud-acceptance-scenarios
+      branch: master


### PR DESCRIPTION
https://github.com/Activiti/Activiti/issues/2225

Haven't included `activiti-modeling-app` as it doesn't use any maven deps.

Need to resolve the error on https://github.com/Activiti/activiti-cloud-modeling/pull/23 as that PR has to be closed before updatebot prs can go to master